### PR TITLE
add structured output to prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,18 @@
-# Take two team names and determine the winner
+# imports
 import random
 from openai import OpenAI
 from dotenv import load_dotenv
 import os
+import json
 
+# load env variables
 load_dotenv(".env")
 PPLX_KEY = os.environ.get("PPLX_KEY")
 
 team1 = "Golden State Warriors"
 team2 = "Denver Nuggets"
 
+# test random winner
 def determineWinner(team1, team2):
     odds = random.randint(0,1)
     if odds > 0.5:
@@ -19,11 +22,22 @@ def determineWinner(team1, team2):
 
     return winner
 
-#test perplexity
+# test perplexity
 messages = [
     {
         "role": "system",
-        "content": "You are an expert in basketball and statistics. You are tasked with researching two teams and determining the most likely winner in a matchup.",
+        "content": """ 
+            You are an expert in basketball and statistics.
+            You are tasked with researching two teams and determining the most likely winner in a matchup.
+            Please return your response in JSON format, with the following fields:
+            ```
+            {
+                "reasoning": ,
+                "winner": ,
+            }
+            ```
+            Return ONLY THE JSON AND NOTHING ELSE.
+            """,
 
     },
     {
@@ -31,7 +45,7 @@ messages = [
         "content": "Denver Nuggets vs. Golden State Warriors",
     }
 ]
-print(PPLX_KEY)
+
 client = OpenAI(api_key=PPLX_KEY, base_url="https://api.perplexity.ai")
 
 response = client.chat.completions.create(
@@ -39,5 +53,14 @@ response = client.chat.completions.create(
     messages=messages,
 )
 
-print(response.content)
+# grab content string
+content = response.choices[0].message.content
+
+# convert to JSON
+content_json = json.loads(content, strict=False)
+winner = content_json["winner"]
+reasoning = content_json["reasoning"]
+
+print(winner)
+print(reasoning)
 


### PR DESCRIPTION
Add structure output to prompt - structured output via prompt guidance rather than perplexity-supported option, which is only available via Tier 3 ($500 in tokens).

Testing: run it a few times, wait until JSON parsing failed, added strict = false variable to json.loads